### PR TITLE
Deprecate HudlSportscode recipes

### DIFF
--- a/Hudl/HudlSportscode.download.recipe
+++ b/Hudl/HudlSportscode.download.recipe
@@ -18,9 +18,18 @@
         <string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_3) AppleWebKit/536.28.10 (KHTML, like Gecko) Version/6.0.3 Safari/536.28.10</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>1.0.0</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to the Hudl Sportscode recipes in the moofit-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
         <dict>
             <key>Processor</key>
             <string>URLTextSearcher</string>

--- a/Hudl/SportsCode.download.recipe
+++ b/Hudl/SportsCode.download.recipe
@@ -21,6 +21,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to the Hudl Sportscode recipes in the moofit-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>URLTextSearcher</string>
             <key>Arguments</key>
             <dict>

--- a/Hudl/SportsCode.download.recipe
+++ b/Hudl/SportsCode.download.recipe
@@ -16,7 +16,7 @@
         <string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_3) AppleWebKit/536.28.10 (KHTML, like Gecko) Version/6.0.3 Safari/536.28.10</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>1.0.0</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
         <dict>


### PR DESCRIPTION
The non-functional HudlSportscode recipes in this repo are insufficiently distinct from recipes elsewhere in the AutoPkg org. This PR deprecates the HudlSportscode recipes in this repo and points users to the working equivalents in the moofit-recipes repo.
